### PR TITLE
Removing redundant code in "getUsage" method

### DIFF
--- a/src/annotations/AnnotationManager.php
+++ b/src/annotations/AnnotationManager.php
@@ -413,11 +413,7 @@ class AnnotationManager
             $usage = $this->getAnnotations($class);
 
             if (count($usage) == 0) {
-                if ($parent = get_parent_class($class)) {
-                    $usage = $this->getUsage($parent);
-                } else {
-                    throw new AnnotationException("the class '{$class}' must have exactly one UsageAnnotation");
-                }
+                throw new AnnotationException("the class '{$class}' must have exactly one UsageAnnotation");
             } else {
                 if (count($usage) !== 1 || !($usage[0] instanceof UsageAnnotation)) {
                     throw new AnnotationException("the class '{$class}' must have exactly one UsageAnnotation (no other Annotations are allowed)");

--- a/test/suite/Annotations.case.php
+++ b/test/suite/Annotations.case.php
@@ -70,6 +70,12 @@ class UninheritableAnnotation extends Annotation
     public $test;
 }
 
+class InheritUsageAnnotation extends SampleAnnotation
+{
+
+
+}
+
 /**
  * @Doc
  * @usage('class'=>true)

--- a/test/suite/Annotations.test.php
+++ b/test/suite/Annotations.test.php
@@ -201,6 +201,12 @@ class AnnotationsTest extends xTest
         Annotations::getUsage('SingleNonUsageAnnotation');
     }
 
+    public function testUsageAnnotationIsInherited()
+    {
+        $usage = Annotations::getUsage('InheritUsageAnnotation');
+        $this->check($usage->method === true);
+    }
+
     protected function testCanGetClassAnnotations()
     {
         $ann = Annotations::ofClass('Test');


### PR DESCRIPTION
Code, that locates parent `@usage` annotation is removed in `getUsage` method in favor code in `getAnnotations` method, that recursively obtains all annotations including ones from parent classes.

Additional test was also added to check specifically inheritance of `@usage` annotation, since it's used to be handled a bit differently usually. Tests, that verifies annotation inheritance in general was already in place by the way.
