### PR TITLE
Unsure that returned annotation indexes are sequential

### DIFF
--- a/src/annotations/AnnotationManager.php
+++ b/src/annotations/AnnotationManager.php
@@ -357,6 +357,9 @@ class AnnotationManager
                 }
             }
         }
+
+        // Ensure sequential indexes in the array after removing annotations from beginning of it.
+        $annotations = array_values($annotations);
     }
 
     /**

--- a/test/suite/Annotations.case.php
+++ b/test/suite/Annotations.case.php
@@ -71,6 +71,24 @@ class UninheritableAnnotation extends Annotation
 }
 
 /**
+ * @Doc
+ * @usage('class'=>true)
+ */
+class UsageAndNonUsageAnnotation extends Annotation
+{
+
+}
+
+/**
+ * @Doc
+ */
+class SingleNonUsageAnnotation extends Annotation
+{
+
+
+}
+
+/**
  * TEST CASE: Sample Classes
  *
  * @doc 1234 (this is a sample PHP-DOC style annotation)

--- a/test/suite/Annotations.test.php
+++ b/test/suite/Annotations.test.php
@@ -181,6 +181,26 @@ class AnnotationsTest extends xTest
         $this->check($usage->multiple === true);
     }
 
+    public function testAnnotationWithNonUsageAndUsageAnnotations()
+    {
+        $this->setExpectedException(
+            'mindplay\annotations\AnnotationException',
+            "the class 'UsageAndNonUsageAnnotation' must have exactly one UsageAnnotation (no other Annotations are allowed)"
+        );
+
+        Annotations::getUsage('UsageAndNonUsageAnnotation');
+    }
+
+    public function testAnnotationWithSingleNonUsageAnnotation()
+    {
+        $this->setExpectedException(
+            'mindplay\annotations\AnnotationException',
+            "the class 'SingleNonUsageAnnotation' must have exactly one UsageAnnotation (no other Annotations are allowed)"
+        );
+
+        Annotations::getUsage('SingleNonUsageAnnotation');
+    }
+
     protected function testCanGetClassAnnotations()
     {
         $ann = Annotations::ofClass('Test');


### PR DESCRIPTION
During a process of filtering out inherited annotations (when annotation was defined as inherited=true+multiple=false) the annotations at the beginning of the annotations array are unset making impossible accessing first found annotation via `$annotations[0]` code.

Applying `array_values` on a result should solve that problem.

In library's code such `[0]` is only present in the `AnnotationManager::getUsage` method (see https://github.com/php-annotations/php-annotations/blob/master/src/annotations/AnnotationManager.php#L419-L423) where presumption that `@usage` annotation should be at 0 index produces PHP warning about accesing undefined array index.

Added tests add missing coverage for `@usage` annotation validation.

Related issue (because `@usage` annotation exactly matches described problem there): #71
