### PR TITLE
Adding missing data types during annotation type resolution code

### DIFF
--- a/src/annotations/AnnotationFile.php
+++ b/src/annotations/AnnotationFile.php
@@ -19,6 +19,27 @@ namespace mindplay\annotations;
 class AnnotationFile
 {
     /**
+     * Data types considered to be simple.
+     *
+     * @var array
+     */
+    private static $simpleTypes = array(
+        'array',
+        'bool',
+        'boolean',
+        'callback',
+        'double',
+        'float',
+        'int',
+        'integer',
+        'mixed',
+        'number',
+        'object',
+        'string',
+        'void',
+    );
+
+    /**
      * @var array hash where member name => annotation data
      */
     public $data;
@@ -83,11 +104,6 @@ class AnnotationFile
      */
     protected function isSimple($type)
     {
-        $data_types = array(
-            'bool', 'int',
-            'mixed', 'string', 'boolean', 'integer', 'float', 'double', 'array',
-        );
-
-        return in_array(strtolower($type), $data_types);
+        return in_array(strtolower($type), self::$simpleTypes);
     }
 }


### PR DESCRIPTION
Following simple data types were added:
- `callback`
- `number`
- `object`
- `void`

Also moving simple data type list to static variable to improve performance.

Closes #77
