### PR TITLE
Fix for PHPDoc Param without type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Naerymdan/annotations",
+    "name": "mindplay/annotations",
     "type": "library",
     "description": "Source-code annotations for PHP",
     "keywords": ["annotations", "framework"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mindplay/annotations",
+    "name": "Naerymdan/annotations",
     "type": "library",
     "description": "Source-code annotations for PHP",
     "keywords": ["annotations", "framework"],

--- a/src/annotations/standard/ParamAnnotation.php
+++ b/src/annotations/standard/ParamAnnotation.php
@@ -53,7 +53,10 @@ class ParamAnnotation extends Annotation implements IAnnotationParser, IAnnotati
     {
         $parts = explode(' ', trim($value), 3);
 
-        return array('type' => $parts[0], 'name' => substr($parts[1], 1));
+        if (isset($parts[1]))
+            return array('type' => $parts[0], 'name' => substr($parts[1], 1));
+        else
+            return array('type' => 'unknown', 'name' => substr($parts[0], 1));
     }
 
     /**

--- a/src/annotations/standard/ParamAnnotation.php
+++ b/src/annotations/standard/ParamAnnotation.php
@@ -53,10 +53,11 @@ class ParamAnnotation extends Annotation implements IAnnotationParser, IAnnotati
     {
         $parts = explode(' ', trim($value), 3);
 
-        if (isset($parts[1]))
+        if (isset($parts[1])) {
             return array('type' => $parts[0], 'name' => substr($parts[1], 1));
-        else
-            return array('type' => 'unknown', 'name' => substr($parts[0], 1));
+        }
+
+        return array('type' => '', 'name' => substr($parts[0], 1));
     }
 
     /**

--- a/test/suite/Annotations.case.php
+++ b/test/suite/Annotations.case.php
@@ -193,6 +193,13 @@ class Test extends TestBase
     public function run()
     {
     }
+
+    /**
+     * @param $value
+     */
+    public function methodWithParam($value)
+    {
+    }
 }
 
 

--- a/test/suite/Annotations.test.php
+++ b/test/suite/Annotations.test.php
@@ -46,7 +46,6 @@ class AnnotationsTest extends xTest
 
         // disable some annotations not used during testing:
         Annotations::getManager()->registry['var'] = false;
-        Annotations::getManager()->registry['param'] = false;
         Annotations::getManager()->registry['undefined'] = 'UndefinedAnnotation';
         $testRunner->stopCoverageCollector();
 
@@ -270,6 +269,12 @@ class AnnotationsTest extends xTest
 
         $annotations = Annotations::ofMethod('Test', 'run');
         $this->check(count($annotations) > 0, 'from class name and method name');
+    }
+
+    protected function testCanGetMethodWithIncompleteParamAnnotations()
+    {
+        $annotations = Annotations::ofMethod(new \ReflectionClass('Test'), 'methodWithParam', 'NoteAnnotation');
+        $this->check(count($annotations) > 0, 'from method with incomplete @Param annotation');
     }
 
     protected function testGetAnnotationsFromMethodOfNonExistingClass()

--- a/test/suite/Annotations.test.php
+++ b/test/suite/Annotations.test.php
@@ -273,8 +273,10 @@ class AnnotationsTest extends xTest
 
     protected function testCanGetMethodWithIncompleteParamAnnotations()
     {
-        $annotations = Annotations::ofMethod(new \ReflectionClass('Test'), 'methodWithParam', 'NoteAnnotation');
+        $annotations = Annotations::ofMethod(new \ReflectionClass('Test'), 'methodWithParam');
         $this->check(count($annotations) > 0, 'from method with incomplete @Param annotation');
+        $this->check($annotations[0]->type == '');
+        $this->check($annotations[0]->name == 'value');
     }
 
     protected function testGetAnnotationsFromMethodOfNonExistingClass()


### PR DESCRIPTION
When a PHPDoc has no type defined for a@Param entry it fails trying to get array index 1.

Ex:

    /**
     * This function does something
     *
     * @param $value
     */
    public static function myFunction($value)
    {
    }