### PR TITLE
Don't trigger notices during malformed `@param` annotation parsing

### DIFF
--- a/src/annotations/standard/ParamAnnotation.php
+++ b/src/annotations/standard/ParamAnnotation.php
@@ -53,6 +53,11 @@ class ParamAnnotation extends Annotation implements IAnnotationParser, IAnnotati
     {
         $parts = explode(' ', trim($value), 3);
 
+        if (count($parts) < 2) {
+            // Malformed value, let "initAnnotation" report about it.
+            return array();
+        }
+
         return array('type' => $parts[0], 'name' => substr($parts[1], 1));
     }
 

--- a/test/suite/Annotations.case.php
+++ b/test/suite/Annotations.case.php
@@ -104,7 +104,8 @@ class SingleNonUsageAnnotation extends Annotation
 
 }
 
-class WrongInterfaceAnnotation {
+class WrongInterfaceAnnotation
+{
 
 }
 
@@ -252,6 +253,19 @@ class TestClassFileAwareAnnotation
 
 }
 
-interface TestInterface {
+interface TestInterface
+{
 
+}
+
+class BrokenParamAnnotationClass
+{
+
+    /**
+     * @param $paramName
+     */
+    protected function brokenParamAnnotation($paramName)
+    {
+
+    }
 }

--- a/test/suite/Annotations.test.php
+++ b/test/suite/Annotations.test.php
@@ -46,7 +46,6 @@ class AnnotationsTest extends xTest
 
         // disable some annotations not used during testing:
         Annotations::getManager()->registry['var'] = false;
-        Annotations::getManager()->registry['param'] = false;
         Annotations::getManager()->registry['undefined'] = 'UndefinedAnnotation';
         $testRunner->stopCoverageCollector();
 
@@ -750,6 +749,17 @@ class AnnotationsTest extends xTest
 
         $this->check($annotations === array(), 'empty annotation list when filtering failed');
     }
+
+    public function testMalformedParamAnnotationThrowsException()
+    {
+        $this->setExpectedException(
+            self::ANNOTATION_EXCEPTION,
+            'ParamAnnotation requires a type property'
+        );
+
+        Annotations::ofMethod('BrokenParamAnnotationClass', 'brokenParamAnnotation');
+    }
+
 }
 
 return new AnnotationsTest;


### PR DESCRIPTION
Solves problem, described in #91 without making any assumptions on what can be data type or param name in malformed `@param` annotation.

No such protection is needed for `@return` and `@var` annotations because with empty value the `parseAnnotation` method, that caused problem for `@param` annotation isn't event called.

Closes #92