### PR TITLE
Don't inherit class/property/method annotations after finding `@stop` annotation on class level

### DIFF
--- a/src/annotations/StopAnnotation.php
+++ b/src/annotations/StopAnnotation.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the php-annotation framework.
+ *
+ * (c) Rasmus Schultz <rasmus@mindplay.dk>
+ *
+ * This software is licensed under the GNU LGPL license
+ * for more information, please see:
+ *
+ * <https://github.com/mindplay-dk/php-annotations>
+ */
+
+namespace mindplay\annotations;
+
+/**
+ * This Annotation indicates that parent class should not be parsed for annotations.
+ *
+ * @usage('class'=>true)
+ */
+class StopAnnotation extends Annotation
+{
+
+
+}

--- a/test/suite/Annotations.case.php
+++ b/test/suite/Annotations.case.php
@@ -195,6 +195,67 @@ class Test extends TestBase
     }
 }
 
+/**
+ * @Note('class-first')
+ */
+class FirstClass
+{
+    /**
+     * @var string
+     * @Note('prop-first')
+     */
+    protected $prop;
+
+    /**
+     * @Note('method-first')
+     */
+    protected function someMethod()
+    {
+
+    }
+}
+
+/**
+ * @Note('class-second')
+ * @stop
+ */
+class SecondClass extends FirstClass
+{
+    /**
+     * @var string
+     * @Note('prop-second')
+     */
+    protected $prop;
+
+    /**
+     * @Note('method-second')
+     */
+    protected function someMethod()
+    {
+
+    }
+}
+
+/**
+ * @Note('class-third')
+ */
+class ThirdClass extends SecondClass
+{
+    /**
+     * @var string
+     * @Note('prop-third')
+     */
+    protected $prop;
+
+    /**
+     * @Note('method-third')
+     */
+    protected function someMethod()
+    {
+
+    }
+}
+
 
 /**
  * Test that using an core class will not break parsing.

--- a/test/suite/Annotations.test.php
+++ b/test/suite/Annotations.test.php
@@ -744,6 +744,57 @@ class AnnotationsTest extends xTest
         $this->check(count($annotations) > 0);
     }
 
+    public function testStopAnnotationPreventsClassLevelAnnotationInheritance()
+    {
+        $annotations = Annotations::ofClass('SecondClass', '@note');
+        $this->check(count($annotations) === 1, 'class level annotation after own "@stop" not present');
+        $this->check($annotations[0]->note === 'class-second', 'non-inherited annotation goes first');
+
+        $annotations = Annotations::ofClass('ThirdClass', '@note');
+        $this->check(count($annotations) === 2, 'class level annotation after parent "@stop" not present');
+        $this->check($annotations[0]->note === 'class-second', 'inherited annotation goes first');
+        $this->check($annotations[1]->note === 'class-third', 'non-inherited annotation goes second');
+    }
+
+    public function testStopAnnotationPreventsPropertyLevelAnnotationInheritance()
+    {
+        $annotations = Annotations::ofProperty('SecondClass', 'prop', '@note');
+        $this->check(count($annotations) === 1, 'property level annotation after own "@stop" not present');
+        $this->check($annotations[0]->note === 'prop-second', 'non-inherited annotation goes first');
+
+        $annotations = Annotations::ofProperty('ThirdClass', 'prop', '@note');
+        $this->check(count($annotations) === 2, 'property level annotation after parent "@stop" not present');
+        $this->check($annotations[0]->note === 'prop-second', 'inherited annotation goes first');
+        $this->check($annotations[1]->note === 'prop-third', 'non-inherited annotation goes second');
+    }
+
+    public function testStopAnnotationPreventsMethodLevelAnnotationInheritance()
+    {
+        $annotations = Annotations::ofMethod('SecondClass', 'someMethod', '@note');
+        $this->check(count($annotations) === 1, 'method level annotation after own "@stop" not present');
+        $this->check($annotations[0]->note === 'method-second', 'non-inherited annotation goes first');
+
+        $annotations = Annotations::ofMethod('ThirdClass', 'someMethod', '@note');
+        $this->check(count($annotations) === 2, 'method level annotation after parent "@stop" not present');
+        $this->check($annotations[0]->note === 'method-second', 'inherited annotation goes first');
+        $this->check($annotations[1]->note === 'method-third', 'non-inherited annotation goes second');
+    }
+
+    public function testDirectAccessToClassIgnoresStopAnnotation()
+    {
+        $annotations = Annotations::ofClass('FirstClass', '@note');
+        $this->check(count($annotations) === 1);
+        $this->check($annotations[0]->note === 'class-first');
+
+        $annotations = Annotations::ofProperty('FirstClass', 'prop', '@note');
+        $this->check(count($annotations) === 1);
+        $this->check($annotations[0]->note === 'prop-first');
+
+        $annotations = Annotations::ofMethod('FirstClass', 'someMethod', '@note');
+        $this->check(count($annotations) === 1);
+        $this->check($annotations[0]->note === 'method-first');
+    }
+
     protected function testFilterUnresolvedAnnotationClass()
     {
         $annotations = Annotations::ofClass('TestBase', false);


### PR DESCRIPTION
Related to #91