### PR TITLE
Fix parsing of PHP file with annotations without context

### DIFF
--- a/test/suite/Annotations.test.php
+++ b/test/suite/Annotations.test.php
@@ -7,6 +7,7 @@ use mindplay\annotations\AnnotationCache;
 use mindplay\annotations\AnnotationManager;
 use mindplay\annotations\Annotations;
 use mindplay\annotations\Annotation;
+use mindplay\annotations\standard\ReturnAnnotation;
 use mindplay\test\annotations\Package;
 use mindplay\test\lib\xTest;
 use mindplay\test\lib\xTestRunner;
@@ -809,6 +810,22 @@ class AnnotationsTest extends xTest
         );
 
         Annotations::ofMethod('BrokenParamAnnotationClass', 'brokenParamAnnotation');
+    }
+
+    protected function testOrphanedAnnotationsAreIgnored()
+    {
+        $manager = new AnnotationManager();
+        $manager->namespace = 'mindplay\test\Sample';
+        $manager->cache = false;
+
+        /** @var Annotation[] $annotations */
+        $annotations = $manager->getMethodAnnotations('mindplay\test\Sample\OrphanedAnnotations', 'someMethod');
+
+        $this->check(count($annotations) == 1, 'the @return annotation was found');
+        $this->check(
+            $annotations[0] instanceof ReturnAnnotation,
+            'the @return annotation has correct type'
+        );
     }
 
 }

--- a/test/suite/Sample/OrphanedAnnotations.php
+++ b/test/suite/Sample/OrphanedAnnotations.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace mindplay\test\Sample;
+
+class OrphanedAnnotations
+{
+
+    /**
+     * Some method.
+     *
+     * @return void
+     */
+    public function someMethod()
+    {
+        $a = 5;
+
+        // @codeCoverageIgnoreStart
+        if (false) {
+            $a = 6;
+        }
+        // @codeCoverageIgnoreEnd
+
+        $a = 5;
+    }
+
+}


### PR DESCRIPTION
1. parsing of PHP file, that contained annotations without context (see #99) is no longer interrupted by exception
2. comments, that may container annotations are parsed only, when their context is determined (class/interface/method/property)

Closes #99