### PR TITLE
Trait docblocks

### DIFF
--- a/test/suite/traits/namespaced.php
+++ b/test/suite/traits/namespaced.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace mindplay\test\traits;
+
+trait AnotherSimpleTrait
+{
+    /**
+     * @note('another-simple-trait')
+     */
+    protected $sampleFromAnotherTrait = 'test';
+
+    /**
+     * @Note('another-simple-trait')
+     */
+    public function runFromAnotherTrait()
+    {
+    }
+}
+
+trait AliasBaseTrait
+{
+    /**
+     * @Note('alias-base-trait')
+     */
+    public function run()
+    {
+    }
+}
+
+trait AliasTrait
+{
+    use \mindplay\test\traits\AliasBaseTrait {
+        \mindplay\test\traits\AliasBaseTrait::run as baseTraitRun;
+    }
+
+    /**
+     * @Note('alias-trait')
+     */
+    public function run()
+    {
+    }
+}
+
+trait InsteadofBaseTraitA
+{
+    /**
+     * @Note('insteadof-base-trait-a')
+     */
+    public function baseTrait()
+    {
+    }
+}
+
+trait InsteadofBaseTraitB
+{
+    /**
+     * @Note('insteadof-base-trait-b')
+     */
+    public function baseTrait()
+    {
+    }
+}
+
+trait InsteadofTraitA
+{
+    use InsteadofBaseTraitA, InsteadofBaseTraitB {
+        InsteadofBaseTraitA::baseTrait insteadof InsteadofBaseTraitB;
+    }
+
+    /**
+     * @Note('insteadof-trait-a')
+     */
+    public function trate()
+    {
+    }
+}
+
+trait InsteadofTraitB
+{
+    use InsteadofBaseTraitA, InsteadofBaseTraitB {
+        InsteadofBaseTraitB::baseTrait insteadof InsteadofBaseTraitA;
+    }
+
+    /**
+     * @Note('insteadof-trait-b')
+     */
+    public function trate()
+    {
+    }
+}

--- a/test/suite/traits/property_conflict.php
+++ b/test/suite/traits/property_conflict.php
@@ -1,0 +1,63 @@
+<?php
+
+trait PropertyConflictTraitOne
+{
+    /**
+     * @Note('property-conflict-trait-one')
+     */
+    protected $traitAndTraitAndParent = 1;
+
+    /**
+     * @Note('property-conflict-trait-one')
+     */
+    protected $unannotatedTraitAndAnnotatedTrait = 1;
+
+    /**
+     * @Note('property-conflict-trait-one')
+     */
+    protected $traitAndParentAndChild = 1;
+
+    /**
+     * @Note('property-conflict-trait-one')
+     */
+    protected $traitAndChild = 1;
+}
+
+trait PropertyConflictTraitTwo
+{
+    /**
+     * @Note('property-conflict-trait-two')
+     */
+    protected $traitAndTraitAndParent = 1;
+
+    protected $unannotatedTraitAndAnnotatedTrait = 1;
+}
+
+class PropertyConflictBaseTraitTester
+{
+    /**
+     * @Note('property-conflict-base-trait-tester')
+     */
+    protected $traitAndTraitAndParent = 1;
+
+    /**
+     * @Note('property-conflict-base-trait-tester')
+     */
+    protected $traitAndParentAndChild = 1;
+}
+
+
+class PropertyConflictTraitTester extends PropertyConflictBaseTraitTester
+{
+    use PropertyConflictTraitTwo, PropertyConflictTraitOne;
+
+    /**
+     * @Note('property-conflict-trait-tester')
+     */
+    protected $traitAndChild = 1;
+
+    /**
+     * @Note('property-conflict-trait-tester')
+     */
+    protected $traitAndParentAndChild = 1;
+}

--- a/test/suite/traits/toplevel.php
+++ b/test/suite/traits/toplevel.php
@@ -1,0 +1,176 @@
+<?php
+
+use mindplay\test\traits\AliasTrait;
+use mindplay\test\traits\InsteadofTraitA;
+
+/**
+ * @note('simple-trait')
+ */
+trait SimpleTrait
+{
+    /**
+     * @note('simple-trait')
+     */
+    protected $sampleFromTrait = 'test';
+
+    /**
+     * @Note('simple-trait')
+     */
+    public function runFromTrait()
+    {
+    }
+}
+
+class SimpleTraitTester
+{
+    use SimpleTrait, mindplay\test\traits\AnotherSimpleTrait;
+}
+
+trait InheritanceBaseTrait
+{
+    /**
+     * @Note('inheritance-base-trait')
+     */
+    public function traitAndParent()
+    {
+    }
+
+    /**
+     * @Note('inheritance-base-trait')
+     */
+    public function baseTraitAndParent()
+    {
+    }
+}
+
+trait InheritanceTrait
+{
+    use InheritanceBaseTrait;
+
+    /**
+     * @Note('inheritance-trait')
+     */
+    public function traitAndParent()
+    {
+    }
+
+    /**
+     * @Note('inheritance-trait')
+     */
+    public function traitAndChild()
+    {
+    }
+
+    /**
+     * @Note('inheritance-trait')
+     */
+    public function traitAndParentAndChild()
+    {
+    }
+}
+
+class InheritanceBaseTraitTester
+{
+    /**
+     * @Note('inheritance-base-trait-tester')
+     */
+    public function baseTraitAndParent()
+    {
+    }
+
+    /**
+     * @Note('inheritance-base-trait-tester')
+     */
+    public function traitAndParent()
+    {
+    }
+
+    /**
+     * @Note('inheritance-base-trait-tester')
+     */
+    public function traitAndParentAndChild()
+    {
+    }
+}
+
+class InheritanceTraitTester extends InheritanceBaseTraitTester
+{
+    use InheritanceTrait;
+
+    /**
+     * @Note('inheritance-trait-tester')
+     */
+    public function traitAndChild()
+    {
+    }
+
+    /**
+     * @Note('inheritance-trait-tester')
+     */
+    public function traitAndParentAndChild()
+    {
+    }
+}
+
+class AliasBaseTraitTester
+{
+    /**
+     * @Note('alias-base-trait-tester')
+     */
+    public function baseTraitRun()
+    {
+    }
+
+    /**
+     * @Note('alias-base-trait-tester')
+     */
+    public function traitRun()
+    {
+    }
+
+    /**
+     * @Note('alias-base-trait-tester')
+     */
+    public function run()
+    {
+    }
+}
+
+class AliasTraitTester extends AliasBaseTraitTester
+{
+    use AliasTrait {
+        AliasTrait::run as traitRun;
+    }
+
+    /**
+     * @Note('alias-trait-tester')
+     */
+    public function run()
+    {
+    }
+}
+
+class InsteadofBaseTraitTester
+{
+    /**
+     * @Note('insteadof-base-trait-tester')
+     */
+    public function trate()
+    {
+    }
+
+    /**
+     * @Note('insteadof-base-trait-tester')
+     */
+    public function baseTrait()
+    {
+    }
+}
+
+class InsteadofTraitTester extends InsteadofBaseTraitTester
+{
+    use InsteadofTraitA, mindplay\test\traits\InsteadofTraitB {
+        InsteadofTraitA::trate insteadof mindplay\test\traits\InsteadofTraitB;
+        mindplay\test\traits\InsteadofTraitB::baseTrait insteadof InsteadofTraitA;
+    }
+}


### PR DESCRIPTION
Given a member or method included from a trait which has an annotation

```php
<?php

trait TestTrait
{
    /**
     * @var SomeType
     */
    public $member;
}

class Test {
     use TestTrait;   
}
```

php-annotations will fail to detect the annotation on $member. This makes traits almost entirely useless if you need to annotate a trait member! [PHPUnit annotations handle this correctly, FWIW.]

I've included a failing test case for this in the first commit and a patch in the second. I realize the patch is unlikely to be accepted in its current form, since it introduces a dependency on the reflection API and `AnnotationParser` might be replaced entirely by #60? But food for thought!