### PR TITLE
Fail test cases when a PHP error occurs after a successful check

### DIFF
--- a/test/lib/xTest.php
+++ b/test/lib/xTest.php
@@ -120,10 +120,6 @@ abstract class xTest
 
                 }
 
-                if (is_null($this->result) && !(($exception instanceof xTestException) && $exception->getCode() == xTestException::FAIL)) {
-                    $this->result = (string)$exception;
-                }
-
                 $count++;
 
                 if ($this->result === true) {
@@ -155,6 +151,9 @@ abstract class xTest
     private function assertException(\Exception $e = null)
     {
         if (!is_string($this->expectedException)) {
+            if ($e && !(($e instanceof xTestException) && $e->getCode() == xTestException::FAIL)) {
+                $this->result = (string)$e;
+            }
             return;
         }
 


### PR DESCRIPTION
Given a test case like

```
public function testIsBroken()
{
    this->check(true, 'dummy value');
    $x[123585];
}
```

the test case will erroneously be marked as passing and the PHP error silently swallowed. This PR ensures that if no exception is expected, the test case is properly failed.