### PR TITLE
Fix top-level use statements

### DIFF
--- a/src/annotations/AnnotationParser.php
+++ b/src/annotations/AnnotationParser.php
@@ -122,7 +122,12 @@ class AnnotationParser
                         $use .= $str;
                     } elseif ($type === self::CHAR) {
                         if ($str === ',' || $str === ';') {
-                            $uses[substr($use, 1 + strrpos($use, '\\'))] = $use;
+                            if (strpos($use, '\\') !== false) {
+                                $uses[substr($use, 1 + strrpos($use, '\\'))] = $use;
+                            }
+                            else {
+                                $uses[$use] = $use;
+                            }
 
                             if ($str === ',') {
                                 $state = self::USE_CLAUSE;

--- a/test/suite/Annotations.test.php
+++ b/test/suite/Annotations.test.php
@@ -111,7 +111,7 @@ class AnnotationsTest extends xTest
         $this->check($file->path === $file_path, 'should reflect path to class-file');
         $this->check($file->namespace === 'mindplay\test\Sample', 'should reflect namespace');
         $this->check(
-            $file->uses === array('SampleAlias' => 'mindplay\annotations\Annotation'),
+            $file->uses === array('Test' => 'Test', 'SampleAlias' => 'mindplay\annotations\Annotation'),
             'should reflect use-clause'
         );
     }

--- a/test/suite/Sample/SampleClass.php
+++ b/test/suite/Sample/SampleClass.php
@@ -2,7 +2,9 @@
 
 namespace mindplay\test\Sample;
 
-use mindplay\annotations\Annotation as SampleAlias; // for AnnotationsTest::testCanGetAnnotationFile()
+// for AnnotationsTest::testCanGetAnnotationFile()
+use Test;
+use mindplay\annotations\Annotation as SampleAlias;
 
 /**
  * @mindplay\test\Sample\Sample


### PR DESCRIPTION
Given a namespaced file which uses a top-level name like

    namespace mindplay;

    use PDO;

the parser will incorrectly generate the following uses information:

    array('DO' => 'PDO')

This commit adjusts the parser to handle use statements which import a
name without a namespace separator.