### PR TITLE
PropertyAnnotation implementation

### DIFF
--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -14,12 +14,81 @@
 namespace mindplay\annotations\standard;
 
 use mindplay\annotations\Annotation;
+use mindplay\annotations\IAnnotationParser;
+use mindplay\annotations\AnnotationException;
+use mindplay\annotations\IAnnotationFileAware;
+use mindplay\annotations\AnnotationFile;
 
 /**
  * Defines a magic/virtual property and it's type
- *
- * @todo implement this
+ * @usage('class'=>true, 'inherited'=>true)
  */
-class PropertyAnnotation extends Annotation
+class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnotationFileAware
 {
+	/**
+	 * @var string Specifies the property type
+	 */
+	public $type;
+	/**
+	 * @var string Specifies the property name
+	 */
+	public $name;
+	/**
+	 * @var string Specifies the property description
+	 */
+	public $description;
+
+	/**
+	 * Annotation file.
+	 *
+	 * @var AnnotationFile
+	 */
+	protected $file;
+
+	/**
+	 * {@inheritDoc}
+	 * @see \mindplay\annotations\IAnnotationParser::parseAnnotation()
+	 */
+	public static function parseAnnotation($value)
+	{
+		$parts = explode(' ', trim($value), 3);
+		if (\sizeof($parts) < 2) {
+			// Malformed value, let "initAnnotation" report about it.
+			return array();
+		}
+		$result=array('type' => $parts[0], 'name' => substr($parts[1], 1));
+
+		if(isset($parts[2])){
+			$result['description']=$parts[2];
+		}
+		return $result;
+	}
+
+	/**
+	 * Initialize the annotation.
+	 */
+	public function initAnnotation(array $properties)
+	{
+		$this->map($properties, array('type','name','description'));
+		parent::initAnnotation($properties);
+		if (!isset($this->type)) {
+			throw new AnnotationException(basename(__CLASS__).' requires a type property');
+		}
+		if (!isset($this->name)) {
+			throw new AnnotationException(basename(__CLASS__).' requires a name property');
+		}
+		$this->type = $this->file->resolveType($this->type);
+	}
+
+	/**
+	 * Provides information about file, that contains this annotation.
+	 *
+	 * @param AnnotationFile $file Annotation file.
+	 *
+	 * @return void
+	 */
+	public function setAnnotationFile(AnnotationFile $file)
+	{
+		$this->file = $file;
+	}
 }

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -63,7 +63,7 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
     {
         $parts = explode(' ', trim($value), 3);
 
-        if (\sizeof($parts) < 2) {
+        if (\count($parts) < 2) {
             // Malformed value, let "initAnnotation" report about it.
             return array();
         }

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -14,34 +14,35 @@
 namespace mindplay\annotations\standard;
 
 use mindplay\annotations\Annotation;
-use mindplay\annotations\IAnnotationParser;
 use mindplay\annotations\AnnotationException;
-use mindplay\annotations\IAnnotationFileAware;
 use mindplay\annotations\AnnotationFile;
+use mindplay\annotations\IAnnotationFileAware;
+use mindplay\annotations\IAnnotationParser;
+
 
 /**
- * Defines a magic/virtual property and it's type
+ * Defines a magic/virtual property and it's type.
  *
  * @usage('class'=>true, 'inherited'=>true)
  */
 class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnotationFileAware
 {
     /**
-     * Specifies the property type
+     * Specifies the property type.
      *
      * @var string 
      */
     public $type;
     
     /**
-     * Specifies the property name
+     * Specifies the property name.
      *
      * @var string
      */
     public $name;
     
     /**
-     * Specifies the property description
+     * Specifies the property description.
      *
      * @var string 
      */
@@ -55,9 +56,11 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
     protected $file;
 
     /**
+     * Parse the standard PHP-DOC "property" annotation.
+     *
      * @param string $value The raw string value of the Annotation.
      *
-     * @return array An array of Annotation properties.
+     * @return array ['type', 'name'] or ['type', 'name', 'description'] if description is set.
      */
     public static function parseAnnotation($value)
     {

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -21,74 +21,91 @@ use mindplay\annotations\AnnotationFile;
 
 /**
  * Defines a magic/virtual property and it's type
+ *
  * @usage('class'=>true, 'inherited'=>true)
  */
 class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnotationFileAware
 {
-	/**
-	 * @var string Specifies the property type
-	 */
-	public $type;
-	/**
-	 * @var string Specifies the property name
-	 */
-	public $name;
-	/**
-	 * @var string Specifies the property description
-	 */
-	public $description;
+    /**
+     * Specifies the property type
+     *
+     * @var string 
+     */
+    public $type;
+    
+    /**
+     * Specifies the property name
+     *
+     * @var string
+     */
+    public $name;
+    
+    /**
+     * Specifies the property description
+     *
+     * @var string 
+     */
+    public $description;
 
-	/**
-	 * Annotation file.
-	 *
-	 * @var AnnotationFile
-	 */
-	protected $file;
+    /**
+     * Annotation file.
+     *
+     * @var AnnotationFile
+     */
+    protected $file;
 
-	/**
-	 * {@inheritDoc}
-	 * @see \mindplay\annotations\IAnnotationParser::parseAnnotation()
-	 */
-	public static function parseAnnotation($value)
-	{
-		$parts = explode(' ', trim($value), 3);
-		if (\sizeof($parts) < 2) {
-			// Malformed value, let "initAnnotation" report about it.
-			return array();
-		}
-		$result=array('type' => $parts[0], 'name' => substr($parts[1], 1));
+    /**
+     * @param string $value The raw string value of the Annotation.
+     *
+     * @return array An array of Annotation properties.
+     */
+    public static function parseAnnotation($value)
+    {
+        $parts = explode(' ', trim($value), 3);
 
-		if (isset($parts[2])){
-			$result['description']=$parts[2];
-		}
-		return $result;
-	}
+        if (\sizeof($parts) < 2) {
+            // Malformed value, let "initAnnotation" report about it.
+            return array();
+        }
 
-	/**
-	 * Initialize the annotation.
-	 */
-	public function initAnnotation(array $properties)
-	{
-		$this->map($properties, array('type','name','description'));
-		parent::initAnnotation($properties);
-		if (!isset($this->type)) {
-			throw new AnnotationException(basename(__CLASS__).' requires a type property');
-		}
-		if (!isset($this->name)) {
-			throw new AnnotationException(basename(__CLASS__).' requires a name property');
-		}
-		$this->type = $this->file->resolveType($this->type);
-	}
+        $result = array('type' => $parts[0], 'name' => substr($parts[1], 1));
 
-	/**
-	 * Provides information about file, that contains this annotation.
-	 *
-	 * @param AnnotationFile $file Annotation file.
-	 *
-	 * @return void
-	 */
-	public function setAnnotationFile(AnnotationFile $file)
-	{
-		$this->file = $file;
-	}
+        if (isset($parts[2])) {
+            $result['description'] = $parts[2];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Initialize the annotation.
+     */
+    public function initAnnotation(array $properties)
+    {
+        $this->map($properties, array('type', 'name', 'description'));
+
+        parent::initAnnotation($properties);
+
+        if (!isset($this->type)) {
+            throw new AnnotationException(basename(__CLASS__).' requires a type property');
+        }
+
+        if (!isset($this->name)) {
+            throw new AnnotationException(basename(__CLASS__).' requires a name property');
+        }
+
+        $this->type = $this->file->resolveType($this->type);
+    }
+
+    /**
+     * Provides information about file, that contains this annotation.
+     *
+     * @param AnnotationFile $file Annotation file.
+     *
+     * @return void
+     */
+    public function setAnnotationFile(AnnotationFile $file)
+    {
+        $this->file = $file;
+    }
 }

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -58,7 +58,7 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
 		}
 		$result=array('type' => $parts[0], 'name' => substr($parts[1], 1));
 
-		if(isset($parts[2])){
+		if (isset($parts[2])){
 			$result['description']=$parts[2];
 		}
 		return $result;

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -63,7 +63,7 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
     {
         $parts = explode(' ', trim($value), 3);
 
-        if (\count($parts) < 2) {
+        if (count($parts) < 2) {
             // Malformed value, let "initAnnotation" report about it.
             return array();
         }


### PR DESCRIPTION
**PropertyAnnotation** was referenced in `AnnotationManager::$registry`
But the PropertyAnnotation class was not implemented.

This causes errors or warnings when a file containing the `@property` annotation is parsed.

This pull request proposes an implementation of the PropertyAnnotation class.