### PR TITLE
slash before php global functions

### DIFF
--- a/src/annotations/Annotation.php
+++ b/src/annotations/Annotation.php
@@ -26,7 +26,7 @@ abstract class Annotation implements IAnnotation
      */
     public function __get($name)
     {
-        throw new AnnotationException(get_class($this) . "::\${$name} is not a valid property name");
+        throw new AnnotationException(\get_class($this) . "::\${$name} is not a valid property name");
     }
 
     /**
@@ -34,7 +34,7 @@ abstract class Annotation implements IAnnotation
      */
     public function __set($name, $value)
     {
-        throw new AnnotationException(get_class($this) . "::\${$name} is not a valid property name");
+        throw new AnnotationException(\get_class($this) . "::\${$name} is not a valid property name");
     }
 
     /**

--- a/src/annotations/AnnotationCache.php
+++ b/src/annotations/AnnotationCache.php
@@ -54,7 +54,7 @@ class AnnotationCache
      */
     public function exists($key)
     {
-        return file_exists($this->_getPath($key));
+        return \file_exists($this->_getPath($key));
     }
 
     /**
@@ -70,11 +70,11 @@ class AnnotationCache
 
         $content = self::PHP_TAG . $code . "\n";
 
-        if (@file_put_contents($path, $content, LOCK_EX) === false) {
+        if (@\file_put_contents($path, $content, LOCK_EX) === false) {
             throw new AnnotationException("Unable to write cache file: {$path}");
         }
 
-        if (@chmod($path, $this->_fileMode) === false) {
+        if (@\chmod($path, $this->_fileMode) === false) {
             throw new AnnotationException("Unable to set permissions of cache file: {$path}");
         }
     }
@@ -98,7 +98,7 @@ class AnnotationCache
      */
     public function getTimestamp($key)
     {
-        return filemtime($this->_getPath($key));
+        return \filemtime($this->_getPath($key));
     }
 
     /**

--- a/src/annotations/AnnotationFile.php
+++ b/src/annotations/AnnotationFile.php
@@ -77,7 +77,7 @@ class AnnotationFile
 
         if (isset($data['#traitMethodOverrides'])) {
             foreach ($data['#traitMethodOverrides'] as $class => $methods) {
-                $this->traitMethodOverrides[$class] = array_map(array($this, 'resolveMethod'), $methods);
+                $this->traitMethodOverrides[$class] = \array_map(array($this, 'resolveMethod'), $methods);
             }
         }
     }
@@ -91,8 +91,8 @@ class AnnotationFile
      */
     public function resolveMethod($raw_method)
     {
-        list($class, $method) = explode('::', $raw_method, 2);
-        return array(ltrim($this->resolveType($class), '\\'), $method);
+        list($class, $method) = \explode('::', $raw_method, 2);
+        return array(\ltrim($this->resolveType($class), '\\'), $method);
     }
 
     /**
@@ -105,18 +105,18 @@ class AnnotationFile
      */
     public function resolveType($raw_type)
     {
-        $type_parts = explode('[]', $raw_type, 2);
+        $type_parts = \explode('[]', $raw_type, 2);
         $type = $type_parts[0];
 
         if (!$this->isSimple($type)) {
             if (isset($this->uses[$type])) {
                 $type_parts[0] = $this->uses[$type];
-            } elseif ($this->namespace && substr($type, 0, 1) != '\\') {
+            } elseif ($this->namespace && \substr($type, 0, 1) != '\\') {
                 $type_parts[0] = $this->namespace . '\\' . $type;
             }
         }
 
-        return implode('[]', $type_parts);
+        return \implode('[]', $type_parts);
     }
 
     /**
@@ -128,6 +128,6 @@ class AnnotationFile
      */
     protected function isSimple($type)
     {
-        return in_array(strtolower($type), self::$simpleTypes);
+        return \in_array(\strtolower($type), self::$simpleTypes);
     }
 }

--- a/src/annotations/AnnotationManager.php
+++ b/src/annotations/AnnotationManager.php
@@ -152,7 +152,7 @@ class AnnotationManager
         $this->_usageAnnotation = new UsageAnnotation();
         $this->_usageAnnotation->class = true;
         $this->_usageAnnotation->inherited = true;
-        $this->_traitsSupported = version_compare(PHP_VERSION, '5.4.0', '>=');
+        $this->_traitsSupported = \version_compare(PHP_VERSION, '5.4.0', '>=');
     }
 
     /**
@@ -195,10 +195,10 @@ class AnnotationManager
                 $code = $this->getParser()->parseFile($path);
                 $data = eval($code);
             } else {
-                $checksum = crc32($path . ':' . $this->_cacheSeed . ':' . self::CACHE_FORMAT_VERSION);
-                $key = basename($path) . '-' . sprintf('%x', $checksum);
+                $checksum = \crc32($path . ':' . $this->_cacheSeed . ':' . self::CACHE_FORMAT_VERSION);
+                $key = \basename($path) . '-' . \sprintf('%x', $checksum);
 
-                if (($this->cache->exists($key) === false) || (filemtime($path) > $this->cache->getTimestamp($key))) {
+                if (($this->cache->exists($key) === false) || (\filemtime($path) > $this->cache->getTimestamp($key))) {
                     $code = $this->getParser()->parseFile($path);
                     $this->cache->store($key, $code);
                 }
@@ -224,19 +224,19 @@ class AnnotationManager
      */
     public function resolveName($name)
     {
-        if (strpos($name, '\\') !== false) {
+        if (\strpos($name, '\\') !== false) {
             return $name . $this->suffix; // annotation class-name is fully qualified
         }
 
-        $type = lcfirst($name);
+        $type = \lcfirst($name);
 
         if (isset($this->registry[$type])) {
             return $this->registry[$type]; // type-name is registered
         }
 
-        $type = ucfirst(strtr($name, '-', '_')) . $this->suffix;
+        $type = \ucfirst(\strtr($name, '-', '_')) . $this->suffix;
 
-        return strlen($this->namespace)
+        return \strlen($this->namespace)
             ? $this->namespace . '\\' . $type
             : $type;
     }
@@ -279,7 +279,7 @@ class AnnotationManager
 
                         unset($spec['#name'], $spec['#type']);
 
-                        if (!class_exists($type, $this->autoload)) {
+                        if (!\class_exists($type, $this->autoload)) {
                             throw new AnnotationException("Annotation type '{$type}' does not exist");
                         }
 
@@ -316,7 +316,7 @@ class AnnotationManager
                         }
                     }
 
-                    $annotations = array_merge($traitAnnotations, $annotations);
+                    $annotations = \array_merge($traitAnnotations, $annotations);
                 }
             }
 
@@ -331,13 +331,13 @@ class AnnotationManager
 
                 if ($parent !== __NAMESPACE__ . '\Annotation') {
                     foreach ($this->getAnnotations($parent, $member_type, $member_name) as $annotation) {
-                        if ($this->getUsage(get_class($annotation))->inherited) {
+                        if ($this->getUsage(\get_class($annotation))->inherited) {
                             $parent_annotations[] = $annotation;
                         }
                     }
                 }
 
-                $annotations = array_merge($parent_annotations, $annotations);
+                $annotations = \array_merge($parent_annotations, $annotations);
             }
 
             $this->annotations[$key] = $this->applyConstraints($annotations, $member_type);
@@ -360,9 +360,9 @@ class AnnotationManager
     protected function classHasMember($className, $memberType, $memberName)
     {
         if ($memberType === self::MEMBER_METHOD) {
-            return method_exists($className, $memberName);
+            return \method_exists($className, $memberName);
         } else if ($memberType === self::MEMBER_PROPERTY) {
-            return property_exists($className, ltrim($memberName, '$'));
+            return \property_exists($className, \ltrim($memberName, '$'));
         }
         return false;
     }
@@ -381,10 +381,10 @@ class AnnotationManager
     protected function applyConstraints(array $annotations, $member)
     {
         $result = array();
-        $annotationCount = count($annotations);
+        $annotationCount = \count($annotations);
 
         foreach ($annotations as $outerIndex => $annotation) {
-            $type = get_class($annotation);
+            $type = \get_class($annotation);
             $usage = $this->getUsage($type);
 
             // Checks, that annotation can be applied to given class/method/property according to it's @usage annotation.
@@ -424,8 +424,8 @@ class AnnotationManager
      */
     protected function filterAnnotations(array $annotations, $type)
     {
-        if (substr($type, 0, 1) === '@') {
-            $type = $this->resolveName(substr($type, 1));
+        if (\substr($type, 0, 1) === '@') {
+            $type = $this->resolveName(\substr($type, 1));
         }
 
         if ($type === false) {
@@ -457,16 +457,16 @@ class AnnotationManager
         }
 
         if (!isset($this->usage[$class])) {
-            if (!class_exists($class, $this->autoload)) {
+            if (!\class_exists($class, $this->autoload)) {
                 throw new AnnotationException("Annotation type '{$class}' does not exist");
             }
 
             $usage = $this->getAnnotations($class);
 
-            if (count($usage) === 0) {
+            if (\count($usage) === 0) {
                 throw new AnnotationException("The class '{$class}' must have exactly one UsageAnnotation");
             } else {
-                if (count($usage) !== 1 || !($usage[0] instanceof UsageAnnotation)) {
+                if (\count($usage) !== 1 || !($usage[0] instanceof UsageAnnotation)) {
                     throw new AnnotationException("The class '{$class}' must have exactly one UsageAnnotation (no other Annotations are allowed)");
                 } else {
                     $usage = $usage[0];
@@ -493,16 +493,16 @@ class AnnotationManager
     {
         if ($class instanceof \ReflectionClass) {
             $class = $class->getName();
-        } elseif (is_object($class)) {
-            $class = get_class($class);
+        } elseif (\is_object($class)) {
+            $class = \get_class($class);
         } else {
-            $class = ltrim($class, '\\');
+            $class = \ltrim($class, '\\');
         }
 
-        if (!class_exists($class, $this->autoload) &&
-            !(function_exists('trait_exists') && trait_exists($class, $this->autoload))
+        if (!\class_exists($class, $this->autoload) &&
+            !(\function_exists('trait_exists') && \trait_exists($class, $this->autoload))
         ) {
-            if (interface_exists($class, $this->autoload)) {
+            if (\interface_exists($class, $this->autoload)) {
                 throw new AnnotationException("Reading annotations from interface '{$class}' is not supported");
             }
 
@@ -534,17 +534,17 @@ class AnnotationManager
         } elseif ($class instanceof \ReflectionMethod) {
             $method = $class->name;
             $class = $class->class;
-        } elseif (is_object($class)) {
-            $class = get_class($class);
+        } elseif (\is_object($class)) {
+            $class = \get_class($class);
         } else {
-            $class = ltrim($class, '\\');
+            $class = \ltrim($class, '\\');
         }
 
-        if (!class_exists($class, $this->autoload)) {
+        if (!\class_exists($class, $this->autoload)) {
             throw new AnnotationException("Unable to read annotations from an undefined class '{$class}'");
         }
 
-        if (!method_exists($class, $method)) {
+        if (!\method_exists($class, $method)) {
             throw new AnnotationException("Unable to read annotations from an undefined method {$class}::{$method}()");
         }
 
@@ -574,17 +574,17 @@ class AnnotationManager
         } elseif ($class instanceof \ReflectionProperty) {
             $property = $class->name;
             $class = $class->class;
-        } elseif (is_object($class)) {
-            $class = get_class($class);
+        } elseif (\is_object($class)) {
+            $class = \get_class($class);
         } else {
-            $class = ltrim($class, '\\');
+            $class = \ltrim($class, '\\');
         }
 
-        if (!class_exists($class, $this->autoload)) {
+        if (!\class_exists($class, $this->autoload)) {
             throw new AnnotationException("Unable to read annotations from an undefined class '{$class}'");
         }
 
-        if (!property_exists($class, $property)) {
+        if (!\property_exists($class, $property)) {
             throw new AnnotationException("Unable to read annotations from an undefined property {$class}::\${$property}");
         }
 

--- a/src/annotations/AnnotationParser.php
+++ b/src/annotations/AnnotationParser.php
@@ -95,8 +95,8 @@ class AnnotationParser
             echo '<table><tr><th>Line</th><th>Type</th><th>String</th><th>State</th><th>Nesting</th></tr>';
         }
 
-        foreach (token_get_all($source) as $token) {
-            list($type, $str, $line) = is_array($token) ? $token : array(self::CHAR, $token, $line);
+        foreach (\token_get_all($source) as $token) {
+            list($type, $str, $line) = \is_array($token) ? $token : array(self::CHAR, $token, $line);
 
             switch ($state) {
                 case self::SCAN:
@@ -131,8 +131,8 @@ class AnnotationParser
                         $use .= $str;
                     } elseif ($type === self::CHAR) {
                         if ($str === ',' || $str === ';') {
-                            if (strpos($use, '\\') !== false) {
-                                $uses[substr($use, 1 + strrpos($use, '\\'))] = $use;
+                            if (\strpos($use, '\\') !== false) {
+                                $uses[\substr($use, 1 + \strrpos($use, '\\'))] = $use;
                             }
                             else {
                                 $uses[$use] = $use;
@@ -218,7 +218,7 @@ class AnnotationParser
 
                 case self::TRAIT_USE_INSTEADOF:
                     if ($type === self::CHAR && $str === ';') {
-                        $traitMethodOverrides[$class][substr($use, strrpos($use, '::') + 2)] = $use;
+                        $traitMethodOverrides[$class][\substr($use, \strrpos($use, '::') + 2)] = $use;
                         $state = self::TRAIT_USE_BLOCK;
                         $use = '';
                     }
@@ -282,8 +282,8 @@ class AnnotationParser
             }
 
             if ($this->debug) {
-                echo "<tr><td>{$line}</td><td>" . token_name($type) . "</td><td>"
-                    . htmlspecialchars($str) . "</td><td>{$state}</td><td>{$nesting}</td></tr>\n";
+                echo "<tr><td>{$line}</td><td>" . \token_name($type) . "</td><td>"
+                    . \htmlspecialchars($str) . "</td><td>{$state}</td><td>{$nesting}</td></tr>\n";
             }
         }
 
@@ -294,17 +294,17 @@ class AnnotationParser
         unset($docblocks);
 
         $code = "return array(\n";
-        $code .= "  '#namespace' => " . var_export($namespace, true) . ",\n";
-        $code .= "  '#uses' => " . var_export($uses, true) . ",\n";
-        $code .= "  '#traitMethodOverrides' => " . var_export($traitMethodOverrides, true) . ",\n";
+        $code .= "  '#namespace' => " . \var_export($namespace, true) . ",\n";
+        $code .= "  '#uses' => " . \var_export($uses, true) . ",\n";
+        $code .= "  '#traitMethodOverrides' => " . \var_export($traitMethodOverrides, true) . ",\n";
 
         foreach ($index as $key => $docblocks) {
             $array = array();
             foreach ($docblocks as $str) {
-                $array = array_merge($array, $this->findAnnotations($str));
+                $array = \array_merge($array, $this->findAnnotations($str));
             }
             if (count($array)) {
-                $code .= "  " . trim(var_export($key, true)) . " => array(\n    " . implode(
+                $code .= "  " . \trim(\var_export($key, true)) . " => array(\n    " . \implode(
                     ",\n    ",
                     $array
                 ) . "\n  ),\n";
@@ -323,7 +323,7 @@ class AnnotationParser
      */
     public function parseFile($path)
     {
-        return $this->parse(file_get_contents($path), $path);
+        return $this->parse(\file_get_contents($path), $path);
     }
 
     /**
@@ -336,8 +336,8 @@ class AnnotationParser
      */
     protected function findAnnotations($str)
     {
-        $str = trim(preg_replace('/^[\/\*\# \t]+/m', '', $str)) . "\n";
-        $str = str_replace("\r\n", "\n", $str);
+        $str = \trim(\preg_replace('/^[\/\*\# \t]+/m', '', $str)) . "\n";
+        $str = \str_replace("\r\n", "\n", $str);
 
         $state = self::SCAN;
         $nesting = 0;
@@ -346,8 +346,8 @@ class AnnotationParser
 
         $matches = array();
 
-        for ($i = 0; $i < strlen($str); $i++) {
-            $char = substr($str, $i, 1);
+        for ($i = 0; $i < \strlen($str); $i++) {
+            $char = \substr($str, $i, 1);
 
             switch ($state) {
                 case self::SCAN:
@@ -367,7 +367,7 @@ class AnnotationParser
                     break;
 
                 case self::NAME:
-                    if (preg_match('/[a-zA-Z\-\\\\]/', $char)) {
+                    if (\preg_match('/[a-zA-Z\-\\\\]/', $char)) {
                         $name .= $char;
                     } elseif ($char == ' ') {
                         $state = self::COPY_LINE;
@@ -419,37 +419,37 @@ class AnnotationParser
                 continue;
             }
 
-            if (!class_exists($type, $this->autoload)) {
+            if (!\class_exists($type, $this->autoload)) {
                 throw new AnnotationException("Annotation type '{$type}' does not exist");
             }
 
             $value = $match[1];
 
-            $quoted_name = "'#name' => " . trim(var_export($name, true));
-            $quoted_type = "'#type' => " . trim(var_export($type, true));
+            $quoted_name = "'#name' => " . \trim(\var_export($name, true));
+            $quoted_type = "'#type' => " . \trim(\var_export($type, true));
 
             if ($value === null) {
                 # value-less annotation:
                 $annotations[] = "array({$quoted_name}, {$quoted_type})";
-            } elseif (substr($value, 0, 1) == '(') {
+            } elseif (\substr($value, 0, 1) == '(') {
                 # array-style annotation:
-                $annotations[] = "array({$quoted_name}, {$quoted_type}, " . substr($value, 1);
+                $annotations[] = "array({$quoted_name}, {$quoted_type}, " . \substr($value, 1);
             } else {
                 # PHP-DOC-style annotation:
-                if (!array_key_exists(__NAMESPACE__ . '\IAnnotationParser', class_implements($type, $this->autoload))) {
+                if (!\array_key_exists(__NAMESPACE__ . '\IAnnotationParser', \class_implements($type, $this->autoload))) {
                     throw new AnnotationException("Annotation type '{$type}' does not support PHP-DOC style syntax (because it does not implement the " . __NAMESPACE__ . "\\IAnnotationParser interface)");
                 }
 
                 /** @var IAnnotationParser $type */
                 $properties = $type::parseAnnotation($value);
 
-                if (!is_array($properties)) {
+                if (!\is_array($properties)) {
                     throw new AnnotationException("Annotation type '{$type}' did not parse correctly");
                 }
 
                 $array = "array({$quoted_name}, {$quoted_type}";
                 foreach ($properties as $name => $value) {
-                    $array .= ", '{$name}' => " . trim(var_export($value, true));
+                    $array .= ", '{$name}' => " . \trim(\var_export($value, true));
                 }
                 $array .= ")";
 

--- a/src/annotations/Annotations.php
+++ b/src/annotations/Annotations.php
@@ -41,7 +41,7 @@ abstract class Annotations
             self::$manager = new AnnotationManager;
         }
 
-        if (is_array(self::$config)) {
+        if (\is_array(self::$config)) {
             foreach (self::$config as $key => $value) {
                 self::$manager->$key = $value;
             }

--- a/src/annotations/standard/ParamAnnotation.php
+++ b/src/annotations/standard/ParamAnnotation.php
@@ -51,14 +51,14 @@ class ParamAnnotation extends Annotation implements IAnnotationParser, IAnnotati
      */
     public static function parseAnnotation($value)
     {
-        $parts = explode(' ', trim($value), 3);
+        $parts = \explode(' ', \trim($value), 3);
 
-        if (count($parts) < 2) {
+        if (\count($parts) < 2) {
             // Malformed value, let "initAnnotation" report about it.
             return array();
         }
 
-        return array('type' => $parts[0], 'name' => substr($parts[1], 1));
+        return array('type' => $parts[0], 'name' => \substr($parts[1], 1));
     }
 
     /**

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -30,21 +30,21 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
     /**
      * Specifies the property type.
      *
-     * @var string 
+     * @var string
      */
     public $type;
-    
+
     /**
      * Specifies the property name.
      *
      * @var string
      */
     public $name;
-    
+
     /**
      * Specifies the property description.
      *
-     * @var string 
+     * @var string
      */
     public $description;
 
@@ -64,14 +64,14 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
      */
     public static function parseAnnotation($value)
     {
-        $parts = explode(' ', trim($value), 3);
+        $parts = \explode(' ', \trim($value), 3);
 
-        if (count($parts) < 2) {
+        if (\count($parts) < 2) {
             // Malformed value, let "initAnnotation" report about it.
             return array();
         }
 
-        $result = array('type' => $parts[0], 'name' => substr($parts[1], 1));
+        $result = array('type' => $parts[0], 'name' => \substr($parts[1], 1));
 
         if (isset($parts[2])) {
             $result['description'] = $parts[2];

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -14,12 +14,81 @@
 namespace mindplay\annotations\standard;
 
 use mindplay\annotations\Annotation;
+use mindplay\annotations\IAnnotationParser;
+use mindplay\annotations\AnnotationException;
+use mindplay\annotations\IAnnotationFileAware;
+use mindplay\annotations\AnnotationFile;
 
 /**
  * Defines a magic/virtual property and it's type
- *
- * @todo implement this
+ * @usage('class'=>true, 'inherited'=>true)
  */
-class PropertyAnnotation extends Annotation
+class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnotationFileAware
 {
+	/**
+	 * @var string Specifies the property type
+	 */
+	public $type;
+	/**
+	 * @var string Specifies the property name
+	 */
+	public $name;
+	/**
+	 * @var string Specifies the property description
+	 */
+	public $description;
+
+	/**
+	 * Annotation file.
+	 *
+	 * @var AnnotationFile
+	 */
+	protected $file;
+
+	/**
+	 * {@inheritDoc}
+	 * @see \mindplay\annotations\IAnnotationParser::parseAnnotation()
+	 */
+	public static function parseAnnotation($value)
+	{
+		$parts = explode(' ', trim($value), 3);
+		if (\sizeof($parts) < 2) {
+			// Malformed value, let "initAnnotation" report about it.
+			return array();
+		}
+		$result=array('type' => $parts[0], 'name' => substr($parts[1], 1));
+
+		if(isset($parts[2])){
+			$result['description']=$parts[2];
+		}
+		return $result;
+	}
+
+	/**
+	 * Initialize the annotation.
+	 */
+	public function initAnnotation(array $properties)
+	{
+		$this->map($properties, array('type','name','description'));
+		parent::initAnnotation($properties);
+		if (!isset($this->type)) {
+			throw new AnnotationException(basename(__CLASS__).' requires a type property');
+		}
+		if (!isset($this->name)) {
+			throw new AnnotationException(basename(__CLASS__).' requires a name property');
+		}
+		$this->type = $this->file->resolveType($this->type);
+	}
+
+	/**
+	 * Provides information about file, that contains this annotation.
+	 *
+	 * @param AnnotationFile $file Annotation file.
+	 *
+	 * @return void
+	 */
+	public function setAnnotationFile(AnnotationFile $file)
+	{
+		$this->file = $file;
+	}
 }

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -63,7 +63,7 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
     {
         $parts = explode(' ', trim($value), 3);
 
-        if (\sizeof($parts) < 2) {
+        if (\count($parts) < 2) {
             // Malformed value, let "initAnnotation" report about it.
             return array();
         }

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -14,34 +14,35 @@
 namespace mindplay\annotations\standard;
 
 use mindplay\annotations\Annotation;
-use mindplay\annotations\IAnnotationParser;
 use mindplay\annotations\AnnotationException;
-use mindplay\annotations\IAnnotationFileAware;
 use mindplay\annotations\AnnotationFile;
+use mindplay\annotations\IAnnotationFileAware;
+use mindplay\annotations\IAnnotationParser;
+
 
 /**
- * Defines a magic/virtual property and it's type
+ * Defines a magic/virtual property and it's type.
  *
  * @usage('class'=>true, 'inherited'=>true)
  */
 class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnotationFileAware
 {
     /**
-     * Specifies the property type
+     * Specifies the property type.
      *
      * @var string 
      */
     public $type;
     
     /**
-     * Specifies the property name
+     * Specifies the property name.
      *
      * @var string
      */
     public $name;
     
     /**
-     * Specifies the property description
+     * Specifies the property description.
      *
      * @var string 
      */
@@ -55,9 +56,11 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
     protected $file;
 
     /**
+     * Parse the standard PHP-DOC "property" annotation.
+     *
      * @param string $value The raw string value of the Annotation.
      *
-     * @return array An array of Annotation properties.
+     * @return array ['type', 'name'] or ['type', 'name', 'description'] if description is set.
      */
     public static function parseAnnotation($value)
     {

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -21,74 +21,91 @@ use mindplay\annotations\AnnotationFile;
 
 /**
  * Defines a magic/virtual property and it's type
+ *
  * @usage('class'=>true, 'inherited'=>true)
  */
 class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnotationFileAware
 {
-	/**
-	 * @var string Specifies the property type
-	 */
-	public $type;
-	/**
-	 * @var string Specifies the property name
-	 */
-	public $name;
-	/**
-	 * @var string Specifies the property description
-	 */
-	public $description;
+    /**
+     * Specifies the property type
+     *
+     * @var string 
+     */
+    public $type;
+    
+    /**
+     * Specifies the property name
+     *
+     * @var string
+     */
+    public $name;
+    
+    /**
+     * Specifies the property description
+     *
+     * @var string 
+     */
+    public $description;
 
-	/**
-	 * Annotation file.
-	 *
-	 * @var AnnotationFile
-	 */
-	protected $file;
+    /**
+     * Annotation file.
+     *
+     * @var AnnotationFile
+     */
+    protected $file;
 
-	/**
-	 * {@inheritDoc}
-	 * @see \mindplay\annotations\IAnnotationParser::parseAnnotation()
-	 */
-	public static function parseAnnotation($value)
-	{
-		$parts = explode(' ', trim($value), 3);
-		if (\sizeof($parts) < 2) {
-			// Malformed value, let "initAnnotation" report about it.
-			return array();
-		}
-		$result=array('type' => $parts[0], 'name' => substr($parts[1], 1));
+    /**
+     * @param string $value The raw string value of the Annotation.
+     *
+     * @return array An array of Annotation properties.
+     */
+    public static function parseAnnotation($value)
+    {
+        $parts = explode(' ', trim($value), 3);
 
-		if (isset($parts[2])){
-			$result['description']=$parts[2];
-		}
-		return $result;
-	}
+        if (\sizeof($parts) < 2) {
+            // Malformed value, let "initAnnotation" report about it.
+            return array();
+        }
 
-	/**
-	 * Initialize the annotation.
-	 */
-	public function initAnnotation(array $properties)
-	{
-		$this->map($properties, array('type','name','description'));
-		parent::initAnnotation($properties);
-		if (!isset($this->type)) {
-			throw new AnnotationException(basename(__CLASS__).' requires a type property');
-		}
-		if (!isset($this->name)) {
-			throw new AnnotationException(basename(__CLASS__).' requires a name property');
-		}
-		$this->type = $this->file->resolveType($this->type);
-	}
+        $result = array('type' => $parts[0], 'name' => substr($parts[1], 1));
 
-	/**
-	 * Provides information about file, that contains this annotation.
-	 *
-	 * @param AnnotationFile $file Annotation file.
-	 *
-	 * @return void
-	 */
-	public function setAnnotationFile(AnnotationFile $file)
-	{
-		$this->file = $file;
-	}
+        if (isset($parts[2])) {
+            $result['description'] = $parts[2];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Initialize the annotation.
+     */
+    public function initAnnotation(array $properties)
+    {
+        $this->map($properties, array('type', 'name', 'description'));
+
+        parent::initAnnotation($properties);
+
+        if (!isset($this->type)) {
+            throw new AnnotationException(basename(__CLASS__).' requires a type property');
+        }
+
+        if (!isset($this->name)) {
+            throw new AnnotationException(basename(__CLASS__).' requires a name property');
+        }
+
+        $this->type = $this->file->resolveType($this->type);
+    }
+
+    /**
+     * Provides information about file, that contains this annotation.
+     *
+     * @param AnnotationFile $file Annotation file.
+     *
+     * @return void
+     */
+    public function setAnnotationFile(AnnotationFile $file)
+    {
+        $this->file = $file;
+    }
 }

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -58,7 +58,7 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
 		}
 		$result=array('type' => $parts[0], 'name' => substr($parts[1], 1));
 
-		if(isset($parts[2])){
+		if (isset($parts[2])){
 			$result['description']=$parts[2];
 		}
 		return $result;

--- a/src/annotations/standard/PropertyAnnotation.php
+++ b/src/annotations/standard/PropertyAnnotation.php
@@ -63,7 +63,7 @@ class PropertyAnnotation extends Annotation implements IAnnotationParser, IAnnot
     {
         $parts = explode(' ', trim($value), 3);
 
-        if (\count($parts) < 2) {
+        if (count($parts) < 2) {
             // Malformed value, let "initAnnotation" report about it.
             return array();
         }

--- a/src/annotations/standard/ReturnAnnotation.php
+++ b/src/annotations/standard/ReturnAnnotation.php
@@ -45,9 +45,9 @@ class ReturnAnnotation extends Annotation implements IAnnotationParser, IAnnotat
      */
     public static function parseAnnotation($value)
     {
-        $parts = explode(' ', trim($value), 2);
+        $parts = \explode(' ', \trim($value), 2);
 
-        return array('type' => array_shift($parts));
+        return array('type' => \array_shift($parts));
     }
 
     /**

--- a/src/annotations/standard/VarAnnotation.php
+++ b/src/annotations/standard/VarAnnotation.php
@@ -66,9 +66,9 @@ class VarAnnotation extends Annotation implements IAnnotationParser, IAnnotation
      */
     public static function parseAnnotation($value)
     {
-        $parts = explode(' ', trim($value), 2);
+        $parts = \explode(' ', \trim($value), 2);
 
-        return array('type' => array_shift($parts));
+        return array('type' => \array_shift($parts));
     }
 
     /**


### PR DESCRIPTION
as agreed...
To prevent php from searching for the function in the current namespace.
Logically, I only added slashes, so I did not ruin the PSR2 compliance.