### PR TITLE
Update getting-started.rst

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -6,19 +6,6 @@ Installation
 ^^^^^^^^^^^^
 Library can be installed using Composer like so:
 
-1. define the dependencies in your ``composer.json``:
-
-.. code-block:: json
-
-    {
-        "require": {
-            "mindplay/annotations": "~1.2"
-        }
-    }
-
-2. install/update your vendors:
-
 .. code-block:: bash
 
-    $ curl http://getcomposer.org/installer | php
-    $ php composer.phar install
+    $ composer require mindplay/annotations


### PR DESCRIPTION
You can require a dependency in one command by using `composer require vendor/package` instead of doing two things (changing composer.json and executing a command). See https://getcomposer.org/doc/03-cli.md#require